### PR TITLE
タスクの登録機能とテストコードを実装した。(+ADRパターンの導入)

### DIFF
--- a/laravel/app/Exceptions/UndefinedStatusException.php
+++ b/laravel/app/Exceptions/UndefinedStatusException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use LogicException;
+
+class UndefinedStatusException extends LogicException
+{
+    public static function fromStatus(string $status): self
+    {
+        return new self(sprintf('Undefined status called: "%s', $status));
+    }
+}

--- a/laravel/app/Http/Actions/Task/GetCreateAction.php
+++ b/laravel/app/Http/Actions/Task/GetCreateAction.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Actions\Task;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responders\Task\GetCreateResponder;
+use Symfony\Component\HttpFoundation\Response;
+
+class GetCreateAction extends Controller
+{
+    private GetCreateResponder $responder;
+
+    public function __construct(GetCreateResponder $responder)
+    {
+        $this->responder = $responder;
+    }
+
+    public function __invoke(): Response
+    {
+        return $this->responder->handle();
+    }
+}

--- a/laravel/app/Http/Actions/Task/PostTaskAction.php
+++ b/laravel/app/Http/Actions/Task/PostTaskAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Actions\Task;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Task\PostTaskRequest;
+use App\Http\Responders\Task\PostTaskResponder;
+use App\Usecase\Task\CreateUsecase;
+use Symfony\Component\HttpFoundation\Response;
+
+class PostTaskAction extends Controller
+{
+    private CreateUsecase $usecase;
+
+    private PostTaskResponder $responder;
+
+    public function __construct(CreateUsecase $usecase, PostTaskResponder $responder)
+    {
+        $this->usecase = $usecase;
+        $this->responder = $responder;
+    }
+
+    public function __invoke(PostTaskRequest $request): Response
+    {
+        return $this->responder->handle($this->usecase->run($request->get('title')));
+    }
+}

--- a/laravel/app/Http/Payload.php
+++ b/laravel/app/Http/Payload.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http;
+
+class Payload
+{
+    public const CREATED = 'CREATED';
+
+    private string $status;
+
+    private $output;
+
+    public function setStatus($status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setOutput($output): self
+    {
+        $this->output = $output;
+
+        return $this;
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
+    }
+}

--- a/laravel/app/Http/Requests/Task/PostTaskRequest.php
+++ b/laravel/app/Http/Requests/Task/PostTaskRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Task;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'max:100'],
+        ];
+    }
+}

--- a/laravel/app/Http/Responders/Task/GetCreateResponder.php
+++ b/laravel/app/Http/Responders/Task/GetCreateResponder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Responders\Task;
+
+use Illuminate\Routing\ResponseFactory;
+use Symfony\Component\HttpFoundation\Response;
+
+class GetCreateResponder
+{
+    private ResponseFactory $responseFactory;
+
+    public function __construct(ResponseFactory $responseFactory)
+    {
+        $this->responseFactory = $responseFactory;
+    }
+
+    public function handle(): Response
+    {
+        return $this->responseFactory->view('tasks.create');
+    }
+}

--- a/laravel/app/Http/Responders/Task/PostTaskResponder.php
+++ b/laravel/app/Http/Responders/Task/PostTaskResponder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Responders\Task;
+
+use App\Exceptions\UndefinedStatusException;
+use App\Http\Payload;
+use Illuminate\Routing\ResponseFactory;
+use Symfony\Component\HttpFoundation\Response;
+
+class PostTaskResponder
+{
+    private ResponseFactory $responseFactory;
+
+    public function __construct(ResponseFactory $responseFactory)
+    {
+        $this->responseFactory = $responseFactory;
+    }
+
+    public function handle(Payload $payload): Response
+    {
+        if ($payload->getStatus() === Payload::CREATED) {
+
+            return $this->responseFactory->redirectToRoute('tasks.get');
+        }
+
+        throw UndefinedStatusException::fromStatus($payload->getStatus());
+    }
+}

--- a/laravel/app/Usecase/Task/CreateUsecase.php
+++ b/laravel/app/Usecase/Task/CreateUsecase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Usecase\Task;
+
+use App\Http\Payload;
+use App\Models\Task;
+
+class CreateUsecase
+{
+    public function run(string $title)
+    {
+        Task::create([
+            'title' => $title,
+            'executed' => false,
+        ]);
+
+        return (new Payload())
+            ->setStatus(Payload::CREATED);
+    }
+}

--- a/laravel/resources/views/tasks/create.blade.php
+++ b/laravel/resources/views/tasks/create.blade.php
@@ -16,21 +16,29 @@
 </head>
 <body>
 <div class="container">
-    <h2>Tasks List</h2>
+    <h2>New Task</h2>
     <div class="row">
-        <div class="col-md-2">
-            {{ link_to_route('tasks.create', '新規追加', [], ['class' => 'btn btn-primary btn-block']) }}
+        <div class="col-md-offset-2 col-md-8">
+            {{ Form::open([
+                'route' => 'tasks.store',
+                'method' => 'post'
+                ]) }}
+            <table class="table table-hover">
+                <thead>
+                <tr>
+                    <td>タイトル</td>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>{{ Form::text('title', '', ['id' => 'title', 'class' => 'form-control']) }}</td>
+                </tr>
+                </tbody>
+            </table>
+            {{ Form::submit('登録', ['class' => 'btn btn-primary']) }}
+            {{ Form::close() }}
         </div>
     </div>
-    <ul>
-        @foreach ($tasks as $task)
-            <li>
-                <a href="{{ route('task.get', [ 'id' => $task->id ]) }}">{{ $task->title }}</a>
-                <input type="checkbox"
-                       name="checkbox_{{ $task->id }}" {!! $task->executed ? 'checked="checked"' : '' !!}>
-            </li>
-        @endforeach
-    </ul>
 </div>
 </body>
 </html>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -17,5 +17,7 @@ Route::get('/', function () {
 });
 
 Route::get('/tasks', Actions\GetTasksAction::class)->name('tasks.get');
+Route::get('/tasks/create', Actions\Task\GetCreateAction::class)->name('tasks.create');
+Route::post('/tasks', Actions\Task\PostTaskAction::class)->name('tasks.store');
 Route::get('/tasks/{id}', Actions\GetTaskAction::class)->where('id', '[0-9]+')->name('task.get');
 Route::put('/tasks/{id}', Actions\PutTaskAction::class)->where('id', '[0-9]+')->name('task.put');

--- a/laravel/tests/Feature/Task/GetCreateActionTest.php
+++ b/laravel/tests/Feature/Task/GetCreateActionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature\Task;
+
+use Tests\TestCase;
+
+class GetCreateActionTest extends TestCase
+{
+    public function testGetCreateAction()
+    {
+        $response = $this->get('/tasks/create');
+
+        $response->assertStatus(200);
+    }
+}

--- a/laravel/tests/Feature/Task/PostTaskActionTest.php
+++ b/laravel/tests/Feature/Task/PostTaskActionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Task;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PostTaskActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testPostTaskAction()
+    {
+        $data = [
+            'title' => '皿洗い',
+        ];
+
+        $this->assertDatabaseMissing('tasks', $data);
+
+        $response = $this->post('/tasks', $data);
+
+        $response->assertStatus(302)
+            ->assertRedirect('/tasks');
+
+        $this->assertDatabaseHas('tasks', $data);
+    }
+}


### PR DESCRIPTION
# 対応内容
- タスクの登録機能とテストコードを実装した。
- ADRパターンの導入

# 動作確認事項
- [x] タスク一覧画面からタスク登録画面に遷移できる。
- [x] タスク登録画面でタスクの名称を入力して登録すると、タスクテーブルにレコードが登録される。
- [x] タスク登録後、タスク一覧画面にリダイレクトする。
- [x] テストがオールグリーンである。